### PR TITLE
add link to nomad-deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Pull requests with additional tools and projects are more than welcome!
 - [smintz/nomadgen](https://github.com/smintz/nomadgen) - Define your Nomad jobspecs using Python.
 - [jet/nomad-service-alerter](https://github.com/jet/nomad-service-alerter) - A tool which provides opt-in alerting for the jobs running on Nomad. It mainly covers Consul Health-check alerts and Restart-Loop (when allocations switch between "pending" and "running" state often due to internal errors) alerts providing integration with PagerDuty.
 - [42wim/nomadctld](https://github.com/42wim/nomadctld) - Ssh server with ability to exec/attach/logs/tail/stop hashicorp nomad containers.
+- [ataccama/nomad-deploy](https://github.com/ataccama/nomad-deploy) - Python3 script that renders a Jinja2 template, plans and registers job. Installable as an executable from [pypi.org](https://pypi.org/project/nomad-deploy/).
 
 ## Tutorials
 - [anubhavmishra/envoy-consul-sds](https://github.com/anubhavmishra/envoy-consul-sds) - A tutorial on how to get Envoy running on Nomad and using Envoy's SDS(Service Discovery Service) to access Consul API.


### PR DESCRIPTION
Hey there!

`nomad-deploy` is a little Python script I wrote for our CI/CD pipeline. It can take variables from different sources - os environment, yaml file or command line arguments - and render them into a Jinja2 template. Then it plans and executes the job on nomad.

There is a readme, some basic CLI documentation, as well as an executable python module that can be installed via Pip.

Cheers :)