### PR TITLE
added hashi-homelab under job files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Pull requests with additional tools and projects are more than welcome!
 ## Job files
 
 - [jrasell/nomadfiles](https://github.com/jrasell/nomadfiles) A collection of Nomad job files for deploying applications to a cluster.
+- [perrymanuk/hashi-homelab](https://github.com/perrymanuk/hashi-homelab) Job files for a small lightweight homelab based on nomad and consul from hashicorp.
 
 ## Utilities
 


### PR DESCRIPTION
Right now this is a collection of job files to deploy a functioning homelab, eventually I would like to also provide an image for a raspberry pi for an easy to use cluster that would be loaded and ready to go from first boot.