### PR TITLE
Adds Nomad Pack and the Nomad Pack Community Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Pull requests with additional tools and projects are more than welcome!
 
 - [data-science-platform/cluster-broccoli](https://github.com/data-science-platform/cluster-broccoli) - Cluster Broccoli is a RESTful web service + UI to manage Nomad jobs through a self service application. Jobs are defined based on templates, allowing for a selectable amount of customization.
 
-## Job files
+## Job Files and Packs
 
+- [hashicorp/nomad-pack-community-registry](https://github.com/hashicorp/nomad-pack-community-registry) - The official community registry for Nomad Pack templates.
 - [jrasell/nomadfiles](https://github.com/jrasell/nomadfiles) A collection of Nomad job files for deploying applications to a cluster.
 - [perrymanuk/hashi-homelab](https://github.com/perrymanuk/hashi-homelab) Job files for a small lightweight homelab based on nomad and consul from hashicorp.
 
@@ -67,6 +68,7 @@ Pull requests with additional tools and projects are more than welcome!
 - [let-sh/nomad-deploy-result-action](https://github.com/let-sh/nomad-deploy-result-action) - A GitHub action for automating Nomad deploys with GitOps.
 - [koyeb/kreconciler](https://github.com/koyeb/kreconciler) - A library for building operators and reconcilers on top of Nomad (or other schedulers).
 - [Roblox/nomad-node-problem-detector](https://github.com/Roblox/nomad-node-problem-detector) - A tool used to detect problems on Nomad nodes based on user-defined health checks.
+- [hashicorp/nomad-pack](https://github.com/hashicorp/nomad-pack) - An official templating tool and package manager for Nomad, currently a Tech Preview.
 
 ## Tutorials
 


### PR DESCRIPTION
Some extra context on Nomad Pack here: https://www.hashicorp.com/blog/announcing-hashicorp-nomad-1-2

I think there is a good chance that other people add Pack repositories (I know we will at least) so I changed the "Job files" section to "Job Files and Packs" to account for any additional repositories that get added.